### PR TITLE
feat: urlbuilder api ergonomics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/urlbuilder/urlbuilder_test.go
+++ b/urlbuilder/urlbuilder_test.go
@@ -10,7 +10,9 @@ func BenchmarkURLBuilder(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		New("https", "example.com").
+		New().
+			Scheme("https").
+			Host("example.com").
 			Path("a").
 			Path("b").
 			Path("c").
@@ -28,7 +30,8 @@ func BenchmarkURLBuilder(b *testing.B) {
 func TestBasicURL(t *testing.T) {
 	t.Parallel()
 
-	got := New("https", "example.com").
+	got := Scheme("https").
+		Host("example.com").
 		Build()
 
 	expected := templ.URL("https://example.com")
@@ -42,7 +45,8 @@ func TestURLWithPaths(t *testing.T) {
 	t.Parallel()
 
 	c := "c"
-	got := New("https", "example.com").
+	got := Scheme("https").
+		Host("example.com").
 		Path("a").
 		Path("b").
 		Path(c).
@@ -58,7 +62,8 @@ func TestURLWithPaths(t *testing.T) {
 func TestURLWithMultipleQueries(t *testing.T) {
 	t.Parallel()
 
-	got := New("https", "example.com").
+	got := Scheme("https").
+		Host("example.com").
 		Path("path").
 		Query("key1", "value1").
 		Query("key2", "value2").
@@ -74,11 +79,12 @@ func TestURLWithMultipleQueries(t *testing.T) {
 func TestURLWithNoPaths(t *testing.T) {
 	t.Parallel()
 
-	got := New("http", "example.org").
+	got := Scheme("https").
+		Host("example.com").
 		Query("search", "golang").
 		Build()
 
-	expected := templ.URL("http://example.org?search=golang")
+	expected := templ.URL("https://example.com?search=golang")
 
 	if got != expected {
 		t.Fatalf("got %s, want %s", got, expected)
@@ -88,7 +94,8 @@ func TestURLWithNoPaths(t *testing.T) {
 func TestURLEscapingPath(t *testing.T) {
 	t.Parallel()
 
-	got := New("https", "example.com").
+	got := Scheme("https").
+		Host("example.com").
 		Path("a/b").
 		Path("c d").
 		Build()
@@ -103,12 +110,136 @@ func TestURLEscapingPath(t *testing.T) {
 func TestURLEscapingQuery(t *testing.T) {
 	t.Parallel()
 
-	got := New("https", "example.com").
+	got := Scheme("https").
+		Host("example.com").
 		Query("key with space", "value with space").
 		Query("key/with/slash", "value/with/slash").
 		Build()
 
 	expected := templ.URL("https://example.com?key+with+space=value+with+space&key%2Fwith%2Fslash=value%2Fwith%2Fslash")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestPath(t *testing.T) {
+	t.Parallel()
+
+	got := Path("chat").
+		Path("response").
+		Query("input", "hello!").
+		Build()
+
+	expected := templ.URL("/chat/response?input=hello%21")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestProtocolRelative(t *testing.T) {
+	t.Parallel()
+
+	got := Host("example.com").Build()
+
+	expected := templ.URL("//example.com")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestSlash(t *testing.T) {
+	t.Parallel()
+
+	got := Path("/").Build()
+
+	expected := templ.URL("/")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestSlashIndex(t *testing.T) {
+	t.Parallel()
+
+	got := Path("/index").Build()
+
+	expected := templ.URL("/index")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestHTTP(t *testing.T) {
+	t.Parallel()
+
+	got := Scheme("http").Host("example.com").Build()
+
+	expected := templ.URL("http://example.com")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestHTTPS(t *testing.T) {
+	t.Parallel()
+
+	got := Scheme("https").Host("example.com").Build()
+
+	expected := templ.URL("https://example.com")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestMailTo(t *testing.T) {
+	t.Parallel()
+
+	got := Scheme("mailto").Host("test@example.com").Build()
+
+	expected := templ.URL("mailto:test@example.com")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestTel(t *testing.T) {
+	t.Parallel()
+
+	got := Scheme("tel").Host("+1234567890").Build()
+
+	expected := templ.URL("tel:+1234567890")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestFtp(t *testing.T) {
+	t.Parallel()
+
+	got := Scheme("ftp").Host("example.com").Build()
+
+	expected := templ.URL("ftp://example.com")
+
+	if got != expected {
+		t.Fatalf("got %s, want %s", got, expected)
+	}
+}
+
+func TestFtps(t *testing.T) {
+	t.Parallel()
+
+	got := Scheme("ftps").Host("example.com").Build()
+
+	expected := templ.URL("ftps://example.com")
 
 	if got != expected {
 		t.Fatalf("got %s, want %s", got, expected)


### PR DESCRIPTION
addresses #4

- changed signature of `urlbuilder.New` from `New(scheme string, host string) *URLBuilder` -> New(s) *URLBuilder`
- helpers that return builders
  - `urlbuilder.Scheme`
  - `urlbuilder.Host`
  - `urlbuilder.Path`
 - additional tests for parity with [`templ.URL`](https://github.com/a-h/templ/blob/main/url.go#L9-L17) and the associated [tests in templ](https://github.com/a-h/templ/blob/main/url_test.go)
 - create .gitignore

TODO once merged, update docs in templ